### PR TITLE
chore: pre-align package.json to mono .rive_head for downstream sync

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "app.rive.rive-unity",
-    "version": "0.3.9-canary.150",
+    "version": "0.0.0",
     "displayName": "Rive",
     "description": "Create and ship interactive animations to any platform",
     "unity": "2020.1",


### PR DESCRIPTION
Updates the downstream package json to what's expected in the rive_head so that changes can be pushed downstream again.